### PR TITLE
bug fix

### DIFF
--- a/lib/master/starter.js
+++ b/lib/master/starter.js
@@ -41,7 +41,7 @@ starter.runServers = function (app) {
  * @return {Void}
  */
 starter.run = function (app, server, cb) {
-  var cmd = util.format('cd %s && node ', app.getBase());
+  var cmd = util.format('cd %s && ' + process.execPath, app.getBase());
   var arg = server.args;
   if (arg !== undefined) {
     cmd += arg;
@@ -133,7 +133,9 @@ starter.localrun = function (cmd, callback) {
   spawnProcess(cmd, null, function (err, data) {
     if (err) {
       console.error('FAILED TO RUN, return code: ' + err);
-      callback('FAILED TO RUN, return code: ' + err);
+      if (callback) {
+  	    callback('FAILED TO RUN, return code: ' + err);
+		  }
     } else {
       if (callback) {
         callback(data);


### PR DESCRIPTION
line 44:fix some ide can't start pomelo.  for example: intellij idea， sublime text. reason: these ide didn't include default path for node "/usr/local/bin"
line 136: if callback is undefine. it cause a exception, then process exit
