### PR TITLE
Add Feature: Channel now can store or read setting values.

### DIFF
--- a/lib/common/service/channelService.js
+++ b/lib/common/service/channelService.js
@@ -166,8 +166,40 @@ var Channel = function(name, service) {
   this.name = name;
   this.groups = {};       // group map for uids. key: sid, value: [uid]
   this.records = {};      // member records. key: uid
+  this.settings = {};     // settings of channel
   this.__channelService__ = service;
   this.state = ST_INITED;
+};
+
+/**
+ * Assign a setting value to a key
+ * @param {String} key setting's key
+ * @param {*} value setting's value
+ * @returns {Channel} for chaining
+ * @memberOf Channel
+ */
+Channel.prototype.set = function(key, value) {
+  if(this.state > ST_INITED) {
+    console.error('Channel has not been inited.');
+  }
+
+  this.settings[key] = value;
+
+  return this;
+};
+
+/**
+ * Get setting by a key
+ * @param {String} key setting's key
+ * @returns {*} the setting's value
+ * @memberOf Channel
+ */
+Channel.prototype.get = function(key) {
+  if(this.state > ST_INITED) {
+    console.error('Channel has not been inited.');
+  }
+
+  return this.settings[key];
 };
 
 /**


### PR DESCRIPTION
By adding two functions to Channel prototype: `set(key, value)` and `get(key)`, now Channel instance can store and read your custom setting values.

For example, as a kind of match game, we created a match room by `channelService.createChannel`.
The room instance needs to hold it's name, it's count of players, it's RoomMaster or it's password to deny players which don't have permission to come in.

So, I added this feature.

---

对 Channel 的原型增加了如下两个方法, 这样Channel 实例便可以存储或读取你自定义的值.
- `set(key, value)`
- `get(key)`
#### 为什么这样做呢

在某些对战类型的游戏中, 服务端通常使用`channelService.createChannel`来创建比赛房间.

而这个房间实例, 往往可能需要保存诸如: 房间名, 房间里的玩家数, 谁是房主, 或者是房主设置的密码, 以阻止不知道密码的玩家进入.
- commit 里, 一个走神, 写错了...忘了store那个单词...
