### PR TITLE
[FixBug] miss first parameter leading rpcInvoke wouldn't call cb function

### DIFF
--- a/lib/components/scheduler.js
+++ b/lib/components/scheduler.js
@@ -33,8 +33,8 @@ Scheduler.prototype.stop = function(force, cb) {
   }
 };
 
-Scheduler.prototype.schedule = function(route, msg, recvs, opts, cb) {
-  this.scheduler.schedule(route, msg, recvs, opts, cb);
+Scheduler.prototype.schedule = function(reqId, route, msg, recvs, opts, cb) {
+  this.scheduler.schedule(reqId, route, msg, recvs, opts, cb);
 };
 
 var getScheduler = function(app, opts) {


### PR DESCRIPTION
[FixBug] miss first parameter leading rpcInvoke wouldn't call cb function
