### PR TITLE
fix bug for spawn args wrong position

### DIFF
--- a/lib/master/starter.js
+++ b/lib/master/starter.js
@@ -45,11 +45,11 @@ starter.run = function (app, server, cb) {
   var cmd, key;
   if (isLocal(server.host)) {
     var options = [];
-    cmd = app.get('main');
-    options.push(cmd);
     if (!!server.args) {
       options.push(server.args);
     }
+    cmd = app.get('main');
+    options.push(cmd);
     options.push(util.format('env=%s',  env));
     for(key in server) {
       options.push(util.format('%s=%s', key, server[key]));


### PR DESCRIPTION
based on http://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options

args(eg: --debug=port) should be first element in the options array.

this pull request will fix a bug mentioned at http://nodejs.netease.com/topic/515251b97f53b3d3330025c7#519eff6a3e8b1fca031b90f1
