### PR TITLE
Add a new method broadcastByServerId.

### DIFF
--- a/lib/common/service/channelService.js
+++ b/lib/common/service/channelService.js
@@ -173,7 +173,7 @@ ChannelService.prototype.broadcastByServerId = function(sid, route, msg, opts, c
   var failIds = [];
   var server = app.getServerById(sid);
 
-  if(!servers) {
+  if(!server) {
     // server does not exist
     utils.invokeCallback(cb);
     return;


### PR DESCRIPTION
Why I do that? Cause I want to send message to a server not servers indicated by type.In a middle network game, we don't need a front server list, we just provide a server list to player and let player to make a choice. Player connects to server he selected, we just push message to players on same server, not to players cross multi-servers.
