### PR TITLE
rpcAfters get the wrong settings 'Constants.KEYWORDS.RPC_BEFORE_FILTER' 

### DIFF
--- a/lib/components/proxy.js
+++ b/lib/components/proxy.js
@@ -67,7 +67,7 @@ pro.start = function(cb) {
     logger.warn('enableRpcLog is deprecated in 0.8.0, please use app.rpcFilter(pomelo.rpcFilters.rpcLog())');
   }
   var rpcBefores = this.app.get(Constants.KEYWORDS.RPC_BEFORE_FILTER);
-  var rpcAfters = this.app.get(Constants.KEYWORDS.RPC_BEFORE_FILTER);
+  var rpcAfters = this.app.get(Constants.KEYWORDS.RPC_AFTER_FILTER);
   var rpcErrorHandler = this.app.get(Constants.RESERVED.RPC_ERROR_HANDLER);
 
   if(!!rpcBefores) {


### PR DESCRIPTION
rpcAfters get the wrong settings 'Constants.KEYWORDS.RPC_BEFORE_FILTER' from app, it should 'Constants.KEYWORDS.RPC_AFTER_FILTER'
