### PR TITLE
Update log.js

### DIFF
--- a/lib/util/log.js
+++ b/lib/util/log.js
@@ -7,4 +7,5 @@ module.exports.configure = function(app, filename) {
   var serverId = app.getServerId();
   var base = app.getBase();
   logger.configure(filename, {serverId: serverId, base: base});
+  app.logger = logger; //增加这个logger，解决在0.8.0加载pomelo-logger不同包，导致无法写入日志的问题
 };


### PR DESCRIPTION
目前我这边0.8.0也发现自定义日志无法写入，确实由于加载的pomelo-logger包不是一个所致，建议在app里增加一个logger的api，这样就方便我们打日志了。

```
 /**
 * Configure pomelo logger
 */
module.exports.configure = function(app, filename) {
  var serverId = app.getServerId();
  var base = app.getBase();
  logger.configure(filename, {serverId: serverId, base: base});
  app.logger = logger; //增加这个
};
```

使用也挺简单

```
var logger = this.app.logger.getLogger('pomelo-gate');
logger.error('*********************** %s', 'mylog mylog');
```

不知道这样会不会有问题，如果不符合pomelo设计方案，那就closed掉吧，不过目前`0.8.x`版本，直接使用如下代码打log确实有问题

```
var rpc_logger = require('pomelo-logger').getLogger('rpc-log', __filename);
```
