### PR TITLE
sshPort: configurable ssh port for distributed deployment

### DIFF
--- a/lib/master/master.js
+++ b/lib/master/master.js
@@ -71,7 +71,7 @@ Server.prototype.start = function(cb) {
 
   // monitor servers register event
   this.masterConsole.on('register', function(record) {
-    starter.bindCpu(record.id, record.pid, record.host);
+    starter.bindCpu(record.id, record.pid, record.host, record.sshPort);
   });
 
   this.masterConsole.on('admin-log', function(log, error) {

--- a/lib/master/starter.js
+++ b/lib/master/starter.js
@@ -81,7 +81,7 @@ starter.run = function(app, server, cb) {
       }
       cmd += util.format(' %s=%s ', key, server[key]);
     }
-    starter.sshrun(cmd, server.host, cb);
+    starter.sshrun(cmd, server.host, server.sshPort, cb);
   }
 };
 
@@ -93,7 +93,7 @@ starter.run = function(app, server, cb) {
  * @param {String} host server host
  * @return {Void}
  */
-starter.bindCpu = function(sid, pid, host) {
+starter.bindCpu = function(sid, pid, host, port){
   if(os.platform() === Constants.PLATFORM.LINUX && cpus[sid] !== undefined) {
     if (utils.isLocal(host)) {
       var options = [];
@@ -104,7 +104,7 @@ starter.bindCpu = function(sid, pid, host) {
     }
     else {
       var cmd = util.format('taskset -pc "%s" "%s"', cpus[sid], pid);
-      starter.sshrun(cmd, host, null);
+      starter.sshrun(cmd, host, port, null);
     }
   }
 };
@@ -137,7 +137,7 @@ starter.kill = function(pids, servers) {
       } else {
         cmd = util.format('kill -9 %s', pids[i]);
       }
-      starter.sshrun(cmd, server.host);
+      starter.sshrun(cmd, server.host, server.sshPort);
     }
   }
 };
@@ -150,9 +150,11 @@ starter.kill = function(pids, servers) {
  * @param {Function} cb callback function
  *
  */
-starter.sshrun = function(cmd, host, cb) {
-  logger.info('Executing ' + cmd + ' on ' + host);
-  spawnProcess(Constants.COMMAND.SSH, host,[host, cmd], cb);
+starter.sshrun = function(cmd, host, port, cb) {
+  if(!port)
+    port = Constants.COMMAND.SSH_DEFAULT_PORT;
+  logger.info('Executing ' + cmd + ' on ' + host + ':' + port);
+  spawnProcess(Constants.COMMAND.SSH, host,[host,  '-p '+port, cmd], cb);
   return;
 };
 

--- a/lib/util/constants.js
+++ b/lib/util/constants.js
@@ -74,7 +74,8 @@ module.exports = {
     TASKSET: 'taskset',
     KILL: 'kill',
     TASKKILL: 'taskkill',
-    SSH: 'ssh'
+    SSH: 'ssh',
+    SSH_DEFAULT_PORT: '22'
   },
 
   PLATFORM: {


### PR DESCRIPTION
http://nodejs.netease.com/topic/5315bdf9104ca22b4237569d

Sometimes we change ssh port for security. This patch works for configurable ssh port in servers.json:

```
{"id": "chat-server-1", "host": "192.168.1.2", "sshPort": 12121, "port": 4010, "frontend": false}
```
