### PR TITLE
Update proxy.js

### DIFF
--- a/lib/components/proxy.js
+++ b/lib/components/proxy.js
@@ -256,6 +256,6 @@ var defaultRoute = function(session, msg, app, cb) {
   }
 
   var uid = session ? (session.uid || '') : '';
-  var index = Math.abs(crc.crc32(uid)) % list.length;
+  var index = Math.abs(crc.crc32(uid.toString())) % list.length;
   utils.invokeCallback(cb, null, list[index].id);
 };


### PR DESCRIPTION
这里crc32这个UID，UID的类型可能是整数，这个CRC库只处理字符串哦。整数永远返回0，这样用默认路由的就无法选择其它服了，比如path那个服
