### PR TITLE
Update protobuf.js

### DIFF
--- a/lib/components/protobuf.js
+++ b/lib/components/protobuf.js
@@ -22,8 +22,8 @@ var Component = function(app, opts) {
   var originClientPath = path.join(app.getBase(), Constants.FILEPATH.CLIENT_PROTOS);
   var presentClientPath = path.join(Constants.FILEPATH.CONFIG_DIR, env, path.basename(Constants.FILEPATH.CLIENT_PROTOS));
 
-  this.serverProtosPath = opts.serverProtos || fs.existsSync(originClientPath) ? Constants.FILEPATH.SERVER_PROTOS : presentServerPath;
-  this.clientProtosPath = opts.clientProtos || fs.existsSync(originServerPath) ? Constants.FILEPATH.CLIENT_PROTOS : presentClientPath;
+  this.serverProtosPath = opts.serverProtos || (fs.existsSync(originClientPath) ? Constants.FILEPATH.SERVER_PROTOS : presentServerPath);
+  this.clientProtosPath = opts.clientProtos || (fs.existsSync(originServerPath) ? Constants.FILEPATH.CLIENT_PROTOS : presentClientPath);
 
   this.setProtos(Constants.RESERVED.SERVER, path.join(app.getBase(), this.serverProtosPath));
   this.setProtos(Constants.RESERVED.CLIENT, path.join(app.getBase(), this.clientProtosPath));


### PR DESCRIPTION
https://github.com/NetEase/pomelo/blob/master/lib/components/protobuf.js#L25
https://github.com/NetEase/pomelo/blob/master/lib/components/protobuf.js#L26
這兩行有bug 
this.serverProtosPath和this.clientProtosPath永遠不會是我傳進去的opts.serverProtos
望修正
看來是重構這塊的時候忽略了三項表達式和||的先後順序
