### PR TITLE
refactor hybridconnector 造成的一個bug

### DIFF
--- a/lib/components/connector.js
+++ b/lib/components/connector.js
@@ -88,7 +88,7 @@ pro.send = function(reqId, route, msg, recvs, opts, cb) {
   var emsg = msg;
   if(this.encode) {
     // use costumized encode
-    emsg = this.encode.call(null, reqId, route, msg);
+    emsg = this.encode.call(this, reqId, route, msg);
   } else if(this.connector.encode) {
     // use connector default encode
     emsg = this.connector.encode(reqId, route, msg);


### PR DESCRIPTION
這一次更新之後https://github.com/NetEase/pomelo/commit/7f185c090245073e0df9beebce190944265ad3d1#diff-c04fb34109c29e0b5612d90d66cef3ca
已經不能通過
pomelo.connectors.hybridconnector.encode/decode 來調取現在的原來的encode和decode了
原先的encode和decode不依賴與上下文，可是重構後的變成依賴上下文的，所以在自定義的encode和decode函數中要保證上下文一致，需要在emsg = this.encode.call(this, reqId, route, msg)時將當前上下文傳遞給自定義的encode函數。
並且在自定義的encode和decode中調用的時候也應該指定上下文為this，比如：
自定義encode中調用原先的encode：
    this.connector.**proto**.encode.call(this.connector, reqId, route, msg)
自定義decode中調用原先的decode：
    this.connector.**proto**.decode.call(this.connector, msg)
