### PR TITLE
Update log4js.json

### DIFF
--- a/template/game-server/config/log4js.json
+++ b/template/game-server/config/log4js.json
@@ -66,7 +66,7 @@
     },
     {
       "type": "file",
-      "filename": "${opts:base}/logs/pomelo.log",
+      "filename": "${opts:base}/logs/pomelo-${opts:serverId}.log",
       "maxLogSize": 1048576,
       "layout": {
           "type": "basic"


### PR DESCRIPTION
很抱歉我加上了这句，我照着这个配置文件，多个进程写日志时，有些进程的日志并没有写到文件中，而且这个会导致内存泄露。我将内存一直泄露的程序dump了下来，发现里面有300万个WriteReq，于是我觉得是log4js那块有BUG，日志write的回调没有被调用。我在线更新了配置文件，为每一个进程配置一个pomelo.log后，内存不再泄露。请验证
