### PR TITLE
解决pomelo多开出现多个没有用的副本问题

### DIFF
--- a/lib/master/master.js
+++ b/lib/master/master.js
@@ -30,8 +30,7 @@ Server.prototype.start = function(cb) {
   // start master console
   this.masterConsole.start(function(err) {
     if(err) {
-      utils.invokeCallback(cb, err);
-      return;
+      process.exit(0);
     }
     moduleUtil.startModules(self.modules, function(err) {
       if(err) {
@@ -48,7 +47,7 @@ Server.prototype.start = function(cb) {
   
   this.masterConsole.on('error', function(err) {
     if(!!err) {
-      logger.error('masterConsole encounters with error: %j', err.stack);
+      logger.error('masterConsole encounters with error: ' + err.stack);
       return;
     }
   });


### PR DESCRIPTION
现在的pomelo如果已经启动一个，再启动的时候还是能成功，于是就多了许多没有用的进程，这个在误操作的时候会造成挺大的麻烦，所以我提交了一个修改到pomelo-admin，如果那边merge了，这边也请看一下，谢谢
