### PR TITLE
Update connector.js

### DIFF
--- a/lib/components/connector.js
+++ b/lib/components/connector.js
@@ -290,18 +290,21 @@ var handleMessage = function(self, session, msg) {
     return;
   }
   self.server.globalHandle(msg, session.toFrontendSession(), function(err, resp, opts) {
-    if(resp) {
-      if(!msg.id) {
-        logger.warn('try to response to a notify: %j', msg.route);
-        return;
-      }
-      opts = {type: 'response', userOptions: opts || {}};
-      // for compatiablity
-      opts.isResponse = true;
-
-      self.send(msg.id, msg.route, resp, [session.id], opts,
-        function() {});
+    if (!resp) resp = {};
+    if (!!err){
+      resp.err = err;
     }
+
+    if(!msg.id) {
+      logger.warn('try to response to a notify: %j', msg.route);
+      return;
+    }
+    opts = {type: 'response', userOptions: opts || {}};
+    // for compatiablity
+    opts.isResponse = true;
+
+    self.send(msg.id, msg.route, resp, [session.id], opts,
+      function() {});
   });
 };
 


### PR DESCRIPTION
lib/components/connector.js line 293, add err upon resp, so that globalHandle always send resp to front, the app can process the err in afterFilter, avoiding no response to front because of 'toobusy' or 'timeout'
