### PR TITLE
fix the warn of "try to response to a notify".

### DIFF
--- a/lib/components/connector.js
+++ b/lib/components/connector.js
@@ -293,7 +293,7 @@ var handleMessage = function(self, session, msg) {
     return;
   }
   self.server.globalHandle(msg, session.toFrontendSession(), function(err, resp, opts) {
-    if(!msg.id) {
+    if(resp && !msg.id) {
       logger.warn('try to response to a notify: %j', msg.route);
       return;
     }


### PR DESCRIPTION
As we know, notify no message id, so when I use : pomelo.notify(route, params) from client, the pomelo game server always have the warning of “try to response to a notify: "gameplay.gpHandler.xxxxx””.

I don’t know why, but when I fixed it by my way, it looks well.
