### PR TITLE
add env param for createMonitorConsole in monitor reconnect

### DIFF
--- a/lib/monitor/monitor.js
+++ b/lib/monitor/monitor.js
@@ -74,7 +74,8 @@ Monitor.prototype.reconnect = function(masterInfo) {
       type: self.app.getServerType(),
       host: masterInfo.host,
       port: masterInfo.port,
-      info: self.serverInfo
+      info: self.serverInfo,
+      env: self.app.get(Constants.RESERVED.ENV),
     });
     self.startConsole(function() {
       logger.info('restart modules for server : %j finish.', self.app.serverId);


### PR DESCRIPTION
See bug https://github.com/NetEase/pomelo/issues/589 for detail.

```
...
// monitor reconnect to master
Monitor.prototype.reconnect = function(masterInfo) {
  var self = this;
  this.stop(function() {
    self.monitorConsole = admin.createMonitorConsole({
      id: self.serverInfo.id,
      type: self.app.getServerType(),
      host: masterInfo.host,
      port: masterInfo.port,
      info: self.serverInfo,
      env: self.app.get(Constants.RESERVED.ENV)
    });
    self.startConsole(function() {
      logger.info('restart modules for server : %j finish.', self.app.serverId);
    });
  });
};
```
