### PR TITLE
close http server after WebSocketServer.close

### DIFF
--- a/lib/connectors/hybrid/wsprocessor.js
+++ b/lib/connectors/hybrid/wsprocessor.js
@@ -48,5 +48,6 @@ Processor.prototype.close = function() {
   this.state = ST_CLOSED;
   this.wsServer.close();
   this.wsServer = null;
+  this.httpServer.close();
   this.httpServer = null;
 };


### PR DESCRIPTION
it's necessary to do this, or your http server is still running for period of time after you call Processor.close.  Set `httpServer = null` wouldn't work. And wsServer.close wouldn't close the http server ( for more please see file `node_modules\ws\lib\WebSocketServer.js : 111`).
BTW, I have no effort to PR this problem for three times Orz.
