### PR TITLE
Upgrade pomelo-protocol to 0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "mkdirp": "0.3.3",
     "pomelo-loader": "0.0.6",
     "pomelo-rpc": "0.4.5",
-    "pomelo-protocol": "0.1.3",
+    "pomelo-protocol": "0.1.4",
     "pomelo-admin": "0.4.1",
     "pomelo-logger": "0.1.6",
     "pomelo-scheduler": "0.3.9",


### PR DESCRIPTION
Upgrade pomelo-protocol to 0.1.4 for [this PR](https://github.com/NetEase/pomelo-protocol/pull/5)

I think most of the dependence should add the prefix `^`,e.g.`"pomelo-protocol": "^0.1.4"`. [Here](https://www.npmjs.org/doc/misc/semver.html) is the Doc.
