### PR TITLE
fix filters.toobusy

### DIFF
--- a/lib/filters/handler/toobusy.js
+++ b/lib/filters/handler/toobusy.js
@@ -31,3 +31,7 @@ Filter.prototype.before = function(msg, session, next) {
     next();
   }
 };
+
+Filter.prototype.after = function(err, msg, session, resp, next) {
+    next();
+};


### PR DESCRIPTION
fix error : /lib/common/service/filterService.js] meet invalid after filter, handler or handler.before should be function.
