### PR TITLE
Revert "fix filters.toobusy"

### DIFF
--- a/lib/filters/handler/toobusy.js
+++ b/lib/filters/handler/toobusy.js
@@ -31,7 +31,3 @@ Filter.prototype.before = function(msg, session, next) {
     next();
   }
 };
-
-Filter.prototype.after = function(err, msg, session, resp, next) {
-    next();
-};


### PR DESCRIPTION
py你看一下，这个filter添加了没有用，多做一步而已，而且next应该是next(err)，这里假如应用那边返回next(new Error())的error会被这边过滤，另外filter那边这个的处理有bug，我提交了一下代码
