### PR TITLE
optimization: remove repeated stringify in encryption

### DIFF
--- a/lib/components/connector.js
+++ b/lib/components/connector.js
@@ -363,7 +363,7 @@ var verifyMessage = function (self, session, msg) {
 
   var message = JSON.stringify(msg.body);
   if(utils.hasChineseChar(message))
-    message = utils.unicodeToUtf8(JSON.stringify(msg.body));
+    message = utils.unicodeToUtf8(message);
 
   return pubKey.verifyString(message, sig);
 };


### PR DESCRIPTION
removed repeated JSON.stringify when converting to utf-8 in signature check,
v8 might not optimize such repeated JSON.stringify, result in doubled overhead, see http://jsperf.com/stringify-repeat
