### PR TITLE
Update servers.json

### DIFF
--- a/template/game-server/config/servers.json
+++ b/template/game-server/config/servers.json
@@ -1,12 +1,12 @@
 {
   "development":{
     "connector": [
-    {"id": "connector-server-1", "host": "127.0.0.1", "port": 3150, "clientPort": 3010, "frontend": true}
+    {"id": "connector-server-1", "host": "127.0.0.1", "port": 3150, "clientHost": "127.0.0.1", "clientPort": 3010, "frontend": true}
     ]
   },
   "production":{
     "connector": [
-    {"id": "connector-server-1", "host": "127.0.0.1", "port": 3150, "clientPort": 3010, "frontend": true}
+    {"id": "connector-server-1", "host": "127.0.0.1", "port": 3150, "clientHost": "127.0.0.1", "clientPort": 3010, "frontend": true}
     ]
   }
 }


### PR DESCRIPTION
这个host跟port是做rpc用的，感觉不适合用这个ip发布到外面，因为换成域名后，rpc的ip也变成了外网ip，这样如果内网的路由没有配置的话，可能内网里面两个机器，外面ip不同，可能他们的rpc走了外网