### PR TITLE
Update protobuf.js

### DIFF
--- a/lib/components/protobuf.js
+++ b/lib/components/protobuf.js
@@ -88,14 +88,16 @@ pro.onUpdate = function(type, path, event) {
   if(event !== 'change') {
     return;
   }
-
+  var self = this;
   fs.readFile(path, 'utf8' ,function(err, data) {
     try {
       var protos = protobuf.parse(JSON.parse(data));
       if(type === Constants.RESERVED.SERVER) {
         protobuf.setEncoderProtos(protos);
+        self.serverProtos = protos;
       } else {
         protobuf.setDecoderProtos(protos);
+        self.clientProtos = protos;
       }
 
       this.version = fs.statSync(path).mtime.getTime();


### PR DESCRIPTION
现在检测是否有某个route的协议有问题，数据没有更新到这个文件，会导致在服务器启动后如果删除了某个route的协议，pomelo还是认为存在该route的协议而对消息encode，此时客户端会返回空