### PR TITLE
改进启动选项,可配置多个

### DIFF
--- a/lib/master/starter.js
+++ b/lib/master/starter.js
@@ -56,7 +56,7 @@ starter.run = function(app, server, cb) {
       if(typeof server.args === 'string') {
         options.push(server.args.trim());
       } else {
-        options.push(server.args);
+        options = options.concat(server.args);
       }
     }
     cmd = app.get(Constants.RESERVED.MAIN);


### PR DESCRIPTION
servers.json里面的args不支持多个node选项,建议改成args可以配置为一个数组