### PR TITLE
TCP socket incorrectly treating split package headers.

### DIFF
--- a/lib/connectors/hybrid/tcpsocket.js
+++ b/lib/connectors/hybrid/tcpsocket.js
@@ -95,12 +95,7 @@ var ondata = function(socket, chunk) {
 
   var offset = 0, end = chunk.length;
 
-  if(socket.state === ST_HEAD && socket.packageBuffer === null && !checkTypeData(chunk[0])) {
-    logger.error('close the connection with invalid head message, the remote ip is %s && port is %s && message is %j', socket._socket.remoteAddress, socket._socket.remotePort, chunk);
-    socket.close();
-  }
-
-  while(offset < end) {
+  while(offset < end && socket.state !== ST_CLOSED) {
     if(socket.state === ST_HEAD) {
       offset = readHead(socket, chunk, offset);
     }
@@ -146,11 +141,20 @@ var readHead = function(socket, data, offset) {
     if(size < 0) {
       throw new Error('invalid body size: ' + size);
     }
-    socket.packageSize = size + socket.headSize;
-    socket.packageBuffer = new Buffer(socket.packageSize);
-    socket.headBuffer.copy(socket.packageBuffer, 0, 0, socket.headSize);
-    socket.packageOffset = socket.headSize;
-    socket.state = ST_BODY;
+    // check if header contains a valid type
+    if(checkTypeData(socket.headBuffer[0])) {
+      socket.packageSize = size + socket.headSize;
+      socket.packageBuffer = new Buffer(socket.packageSize);
+      socket.headBuffer.copy(socket.packageBuffer, 0, 0, socket.headSize);
+      socket.packageOffset = socket.headSize;
+      socket.state = ST_BODY;
+    }
+    else {
+      dend = data.length;
+      logger.error('close the connection with invalid head message, the remote ip is %s && port is %s && message is %j', socket._socket.remoteAddress, socket._socket.remotePort, data);
+      socket.close();
+    }
+
   }
 
   return dend;


### PR DESCRIPTION
When the package header (package type + package length) is split among two TCP packets, tcpsocket.js will handle the beginning of the package header correctly and wait for the remaining header to be received. However when the rest of the package header is received, tcpsocket.js will then test if the first byte received (which is part of the package length) is once again a valid package type, which will fail and the connection will be closed. This pull requests fixes that issue by testing for a valid header only after the entire header is received. The disconnection behavior is maintained.