### PR TITLE
handshake request parse error fix

### DIFF
--- a/lib/connectors/commands/handshake.js
+++ b/lib/connectors/commands/handshake.js
@@ -32,6 +32,11 @@ var Command = function(opts) {
 module.exports = Command;
 
 Command.prototype.handle = function(socket, msg) {
+  if(!msg.sys) {
+    processError(socket, CODE_USE_ERROR);
+    return;
+  }
+
   if(typeof this.checkClient === 'function') {
     if(!msg || !msg.sys || !this.checkClient(msg.sys.type, msg.sys.version)) {
       processError(socket, CODE_OLD_CLIENT);

--- a/lib/connectors/common/coder.js
+++ b/lib/connectors/common/coder.js
@@ -35,7 +35,11 @@ var decode = function(msg) {
   } else if(!!this.decodeIO_protobuf && !!this.decodeIO_protobuf.check(Constants.RESERVED.CLIENT, route)) {
     msg.body = this.decodeIO_protobuf.decode(route, msg.body);
   } else {
-    msg.body = JSON.parse(msg.body.toString('utf8'));
+    try {
+      msg.body = JSON.parse(msg.body.toString('utf8'));
+    } catch (ex) {
+      msg.body = {};
+    }
   }
 
   return msg;

--- a/lib/connectors/common/handler.js
+++ b/lib/connectors/common/handler.js
@@ -13,7 +13,11 @@ var handleHandshake = function(socket, pkg) {
   if(socket.state !== ST_INITED) {
     return;
   }
-  socket.emit('handshake', JSON.parse(protocol.strdecode(pkg.body)));
+  try {
+    socket.emit('handshake', JSON.parse(protocol.strdecode(pkg.body)));
+  } catch (ex) {
+    socket.emit('handshake', {});
+  }
 };
 
 var handleHandshakeAck = function(socket, pkg) {


### PR DESCRIPTION
Problem occured after pomelo client (unity 3d version) tried to handshake with the server. And the errror was an accident, which happened after removing ending quotes for JSON keys for handshake message (so it's not pomelo unity 3d client error, it's a server error). Then the game server crashed with following message:
```
{type":"unity-socket", version":"1.0.0"}
 ^

SyntaxError: Unexpected token t
    at Object.parse (native)
    at decode (/home/ovos/lebensnets/game-server/node_modules/pomelo/lib/connectors/common/coder.js:38:21)
    at null.<anonymous> (/home/ovos/lebensnets/game-server/node_modules/pomelo/lib/components/connector.js:223:29)
    at emit (events.js:95:17)
    at handleData (/home/ovos/lebensnets/game-server/node_modules/pomelo/lib/connectors/common/handler.js:42:10)
    at handle (/home/ovos/lebensnets/game-server/node_modules/pomelo/lib/connectors/common/handler.js:53:5)
    at null.<anonymous> (/home/ovos/lebensnets/game-server/node_modules/pomelo/lib/connectors/hybridsocket.js:41:7)
    at emit (events.js:95:17)
    at readBody (/home/ovos/lebensnets/game-server/node_modules/pomelo/lib/connectors/hybrid/tcpsocket.js:183:12)
    at ondata (/home/ovos/lebensnets/game-server/node_modules/pomelo/lib/connectors/hybrid/tcpsocket.js:104:16)
```
logging for this case is:
```
[2015-08-13 13:59:47.404] [INFO] crash-log - [.../node_modules/pomelo/lib/master/master.js] [connector],[connector-1],[1439467187404],[disconnect]

[2015-08-13 13:59:47.405] [WARN] pomelo - [.../node_modules/pomelo/lib/master/starter.js] child process exit with error, error code: 8, executed command: /usr/bin/nodejs
```

This means that any client sending incorrect handshake message could stop the server with process error.