### PR TITLE
Fixed bug of decoding an array that is too large (typically 64K)

### DIFF
--- a/template/web-server/public/js/lib/build/build.js
+++ b/template/web-server/public/js/lib/build/build.js
@@ -467,7 +467,14 @@ require.register("NetEase-pomelo-protocol/lib/protocol.js", function(exports, re
       }
       array.push(charCode);
     }
-    return String.fromCharCode.apply(null, array);
+    var res = '';
+    var chunk = 8 * 1024;
+    var i;
+    for (i = 0; i < array.length / chunk; i++) {
+        res += String.fromCharCode.apply(null, array.slice(i * chunk, (i + 1) * chunk));
+    }
+    res += String.fromCharCode.apply(null, array.slice(i * chunk));
+    return res;
   };
 
   /**


### PR DESCRIPTION
When decoded a too large array, it may cause `Error: Uncaught RangeError: Maximum call stack size exceeded.`
Fix it.