### PR TITLE
Fixed a bug in redismonitor that crashed the app

### DIFF
--- a/lib/monitors/redismonitor.js
+++ b/lib/monitors/redismonitor.js
@@ -25,6 +25,7 @@ module.exports = Monitor;
 
 Monitor.prototype.start = function(cb) {
   var self = this;
+  self.started = false;
   if(this.mode === 'single') {
     this.client = new Redis(this.redisNodes.port, this.redisNodes.host, this.redisOpts);
   } else {
@@ -41,7 +42,6 @@ Monitor.prototype.start = function(cb) {
       self.client.auth(self.password);
     }
     watcherCluster2Command.call(self);
-    self.timer = setInterval(watcherCluster2Command.bind(self), self.period);
 
     if(self.mode === 'multiple') {
       clearPingTimer(self, function() {
@@ -49,8 +49,11 @@ Monitor.prototype.start = function(cb) {
       });
     }
 
-    utils.invokeCallback(cb);
-
+    if(!self.started) {
+      self.started = true;
+      self.timer = setInterval(watcherCluster2Command.bind(self), self.period);
+      utils.invokeCallback(cb);
+    }
   });
 
   this.client.on('error', function(error) {


### PR DESCRIPTION
When the redis client disconnected and reconnected it tried to start
the app again and listen to the port already in use.

The fix ensures the connect callback is called just once to avoid
this bug.
