### PR TITLE
mor flexibility for server handlers

### DIFF
--- a/lib/common/service/handlerService.js
+++ b/lib/common/service/handlerService.js
@@ -42,15 +42,19 @@ Service.prototype.handle = function(routeRecord, msg, session, cb) {
         time : utils.format(new Date(start)),
         timeUsed : new Date() - start
       };
-      if(typeof resp === 'undefined') resp = {};
+      if(typeof resp === 'undefined' && this.app.get('enfrceHandlerResponse')) resp = {};
       forwardLogger.info(JSON.stringify(log));
       utils.invokeCallback(cb, err, resp, opts);
     });
   }catch(err){
-    process.nextTick(function(){
-      var opts;
-      utils.invokeCallback(cb, err, {}, opts);
-    });
+    if(this.app.get('catchHandlerErrors')){
+      process.nextTick(function(){
+        var opts;
+        utils.invokeCallback(cb, err, {}, opts);
+      });
+    }else{
+      throw err;
+    }
   }
   return;
 };

--- a/lib/common/service/handlerService.js
+++ b/lib/common/service/handlerService.js
@@ -34,17 +34,24 @@ Service.prototype.handle = function(routeRecord, msg, session, cb) {
     return;
   }
   var start = Date.now();
-
-  handler[routeRecord.method](msg, session, function(err, resp, opts) {
-    var log = {
-      route : msg.__route__,
-      args : msg,
-      time : utils.format(new Date(start)),
-      timeUsed : new Date() - start
-    };
-    forwardLogger.info(JSON.stringify(log));
-    utils.invokeCallback(cb, err, resp, opts);
-  });
+  try{
+    handler[routeRecord.method](msg, session, function(err, resp, opts) {
+      var log = {
+        route : msg.__route__,
+        args : msg,
+        time : utils.format(new Date(start)),
+        timeUsed : new Date() - start
+      };
+      if(typeof resp === 'undefined') resp = {};
+      forwardLogger.info(JSON.stringify(log));
+      utils.invokeCallback(cb, err, resp, opts);
+    });
+  }catch(err){
+    process.nextTick(function(){
+      var opts;
+      utils.invokeCallback(cb, err, {}, opts);
+    });
+  }
   return;
 };
 


### PR DESCRIPTION
improved error-handling for handlers
improved capabilities for after filters

actually we have two changes here.
1. when the handler calls the next function, the handler makes sure, there is something as response. Minimum an empty object. By that, after-filters can handle the error and change the response object.
2. try catch around executing the handler. This can allow the to use validation libraries that throw errors. or throw errors themself. Now the only way is to call use "next(err);return"; or "if(..){...next();}else...". So the try catch will help to write cleaner code in the handler. 