### PR TITLE
server-handlers, errorhandling configurable

### DIFF
--- a/lib/common/service/handlerService.js
+++ b/lib/common/service/handlerService.js
@@ -42,15 +42,19 @@ Service.prototype.handle = function(routeRecord, msg, session, cb) {
         time : utils.format(new Date(start)),
         timeUsed : new Date() - start
       };
-      if(typeof resp === 'undefined') resp = {};
+      if(typeof resp === 'undefined' && this.app.get('enfrceHandlerResponse')) resp = {};
       forwardLogger.info(JSON.stringify(log));
       utils.invokeCallback(cb, err, resp, opts);
     });
   }catch(err){
-    process.nextTick(function(){
-      var opts;
-      utils.invokeCallback(cb, err, {}, opts);
-    });
+    if(this.app.get('catchHandlerErrors')){
+      process.nextTick(function(){
+        var opts;
+        utils.invokeCallback(cb, err, {}, opts);
+      });
+    }else{
+      throw err;
+    }
   }
   return;
 };

--- a/lib/common/service/handlerService.js
+++ b/lib/common/service/handlerService.js
@@ -34,17 +34,24 @@ Service.prototype.handle = function(routeRecord, msg, session, cb) {
     return;
   }
   var start = Date.now();
-
-  handler[routeRecord.method](msg, session, function(err, resp, opts) {
-    var log = {
-      route : msg.__route__,
-      args : msg,
-      time : utils.format(new Date(start)),
-      timeUsed : new Date() - start
-    };
-    forwardLogger.info(JSON.stringify(log));
-    utils.invokeCallback(cb, err, resp, opts);
-  });
+  try{
+    handler[routeRecord.method](msg, session, function(err, resp, opts) {
+      var log = {
+        route : msg.__route__,
+        args : msg,
+        time : utils.format(new Date(start)),
+        timeUsed : new Date() - start
+      };
+      if(typeof resp === 'undefined') resp = {};
+      forwardLogger.info(JSON.stringify(log));
+      utils.invokeCallback(cb, err, resp, opts);
+    });
+  }catch(err){
+    process.nextTick(function(){
+      var opts;
+      utils.invokeCallback(cb, err, {}, opts);
+    });
+  }
   return;
 };
 


### PR DESCRIPTION
last week I already proposed an update for the handler-service. that will allow a better error-handling.
by allowing afterfilters to send a reasonable result to the client 
and  catching sync errors in the handler, to not let them get catched on the mail-service but be handled by afterfilters.

I was told, the change should be configurable. so I used **app.get('enfrceHandlerResponse')**
and **app.get('catchHandlerErrors')** to enable both features manually in app.js.
