### PR TITLE
fix auto-restart option when server has arguments

### DIFF
--- a/lib/master/starter.js
+++ b/lib/master/starter.js
@@ -73,7 +73,7 @@ starter.run = function(app, server, cb) {
     cmd = util.format('cd "%s" && "%s"', app.getBase(), process.execPath);
     var arg = server.args;
     if (arg !== undefined) {
-      cmd += arg;
+      cmd += ' ' + arg;
     }
     cmd += util.format(' "%s" env=%s ', app.get(Constants.RESERVED.MAIN), env);
     for(key in server) {


### PR DESCRIPTION
I've added arguments to one of my servers and enabled auto-restart

I tried with the space in args like in your documentation but a wild 0 appeared concatenated to the node executable when master tried to restart it resulting in an unknown file error.

I removed the space from args in servers.config and when the master wanted to restart the server the executable and the arguments were concatenated resulting in the same error.

Adding the space in the code fixed it and removing the space in the config worked for me

