### PR TITLE
config/servers.json里的server配置支持clientHost属性

### DIFF
--- a/lib/components/connector.js
+++ b/lib/components/connector.js
@@ -163,13 +163,15 @@ var getConnector = function(app, opts) {
   }
 
   var curServer = app.getCurServer();
-  return connector(curServer.clientPort, curServer.host, opts);
+  var host = curServer.clientHost || curServer.host;
+  return connector(curServer.clientPort, host, opts);
 };
 
 var getDefaultConnector = function(app, opts) {
   var DefaultConnector = require('../connectors/sioconnector');
   var curServer = app.getCurServer();
-  return new DefaultConnector(curServer.clientPort, curServer.host, opts);
+  var host = curServer.clientHost || curServer.host;
+  return new DefaultConnector(curServer.clientPort, host, opts);
 };
 
 var hostFilter = function(cb, socket) {


### PR DESCRIPTION
config/servers.json里的server配置支持添加clientHost属性，让frontend server能够用不同的ip地址给RPC和客户端提供服务