### PR TITLE
Updating engine.io configuration methods.

### DIFF
--- a/lib/connectors/sioconnector.js
+++ b/lib/connectors/sioconnector.js
@@ -1,6 +1,6 @@
 var util = require('util');
 var EventEmitter = require('events').EventEmitter;
-var httpServer = require('http').createServer();
+var sio = require('socket.io');
 var SioSocket = require('./siosocket');
 
 var PKG_ID_BYTES = 4;
@@ -38,34 +38,26 @@ module.exports = Connector;
 Connector.prototype.start = function(cb) {
   var self = this;
   // issue https://github.com/NetEase/pomelo-cn/issues/174
-  var opts = {}
-  if(!!this.opts) {
-    opts = this.opts;
-  }
-  else {
-    opts = {
+  if (!!this.opts) {
+    this.wsocket = sio.listen(this.port, this.opts);
+  } else {
+    this.wsocket = sio.listen(this.port, {
       transports: [
-      'websocket', 'polling-xhr', 'polling-jsonp', 'polling'
-      ]
-    };
+        'websocket', 'htmlfile', 'xhr-polling', 'jsonp-polling', 'flashsocket'
+      ],
+      pingTimeout: this.heartbeatTimeout,
+      pingInterval: this.heartbeatInterval
+    });
   }
 
-  var sio = require('socket.io')(httpServer, opts);
-
-  var port = this.port;
-  httpServer.listen(port, function () {
-    console.log('sio Server listening at port %d', port);
-  });
-  sio.set('resource', '/socket.io');
-  sio.set('transports', this.opts.transports);
-  sio.set('heartbeat timeout', this.heartbeatTimeout);
-  sio.set('heartbeat interval', this.heartbeatInterval);
-
-  sio.on('connection', function (socket) {
+  this.wsocket.sockets.on('connection', function(socket) {
     var siosocket = new SioSocket(curId++, socket);
     self.emit('connection', siosocket);
     siosocket.on('closing', function(reason) {
-      siosocket.send({route: 'onKick', reason: reason});
+      siosocket.send({
+        route: 'onKick',
+        reason: reason
+      });
     });
   });
 
@@ -81,7 +73,7 @@ Connector.prototype.stop = function(force, cb) {
 };
 
 Connector.encode = Connector.prototype.encode = function(reqId, route, msg) {
-  if(reqId) {
+  if (reqId) {
     return composeResponse(reqId, route, msg);
   } else {
     return composePush(route, msg);
@@ -126,13 +118,16 @@ var composeResponse = function(msgId, route, msgBody) {
 };
 
 var composePush = function(route, msgBody) {
-  return JSON.stringify({route: route, body: msgBody});
+  return JSON.stringify({
+    route: route,
+    body: msgBody
+  });
 };
 
 var parseIntField = function(str, offset, len) {
   var res = 0;
-  for(var i=0; i<len; i++) {
-    if(i > 0) {
+  for (var i = 0; i < len; i++) {
+    if (i > 0) {
       res <<= 8;
     }
     res |= str.charCodeAt(offset + i) & 0xff;


### PR DESCRIPTION
The pomelo socket.io connector is throwing errors trying to connect from another node.js server, using socket.io-client.

Actually i found that:
https://github.com/NetEase/pomelo/blob/master/lib/connectors/sioconnector.js#L59

It's a deprecated method, as you can see on:
https://socket.io/docs/migrating-from-0-9/

> The old io.set() and io.get() methods are deprecated and only supported for backwards compatibility. Here is a translation of an old authorization example into middleware-style.

References to issue: https://github.com/NetEase/pomelo/issues/956