### PR TITLE
BUG FIXED: all channel members are restored wrong

### DIFF
--- a/lib/common/service/channelService.js
+++ b/lib/common/service/channelService.js
@@ -462,7 +462,7 @@ var restoreChannel = function(self, cb) {
           utils.invokeCallback(cb);
           return;
         }
-        var load = function(key) {
+        var load = function(key, name) {
           return (function() {
             loadAllFromStore(self, key, function(err, items) {
               for(var j=0; j<items.length; j++) {
@@ -482,7 +482,7 @@ var restoreChannel = function(self, cb) {
        for(var i=0; i<list.length; i++) {
         var name = list[i].slice(genKey(self).length + 1);
         self.channels[name] = new Channel(name, self);
-        load(list[i]);
+        load(list[i], name);
       }
       utils.invokeCallback(cb);
     }


### PR DESCRIPTION
BUG RESOLVED:
all channel members were restored in wrong (mostly in last) channel, 
due to over-written value of 'name'
- because for loop runs fast and callback (in "load" function) gets the value of 'name' wrong.

----
We were working with 'restoring channels data' from DB after server restarts (after unexpected crash).
and We found that members were added to wrong channel(s).