### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "10.15.0"
 before_script:
   - npm install -g grunt-cli


### PR DESCRIPTION
升级travis的node版本，目前travis的node版本过低自动测试总是失败